### PR TITLE
追加実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,8 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
-
+gem 'redcarpet', '~> 2.3.0'
+gem 'coderay'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     regexp_parser (2.2.0)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -258,6 +259,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  coderay
   devise
   factory_bot_rails
   faker
@@ -269,6 +271,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  redcarpet (~> 2.3.0)
   rspec-rails
   sass-rails (~> 5)
   selenium-webdriver

--- a/app/assets/stylesheets/messages.css
+++ b/app/assets/stylesheets/messages.css
@@ -54,13 +54,14 @@
 .chat-header {
   height: 100px;
   padding: 0 40px;
+  background-color: #008080;
   display: flex;
   justify-content: space-between;
 }
 
 .header-title {
-  color: #333;
-  font-size: 24px;
+  color: #FAFAFA;
+  font-size: 40px;
   margin-top: 36px;
 }
 
@@ -70,14 +71,14 @@
 
 .header-button a {
   text-decoration: none;
-  border: 1px solid darkred;
-  color: darkred;
+  border: 1px solid #FAFAFA;
+  color: #FAFAFA;
   padding: 20px;
 }
 
 .messages {
   background-color: #FAFAFA;
-  height: calc(100vh - 100px - 90px);
+  height: calc(100vh - 100px - 200px);
   padding: 46px 40px 0;
   overflow: scroll;
 }
@@ -113,7 +114,7 @@
 
 .form{
   background-color: #DDDDDD;
-  height: 90px;
+  height: 200px;
   padding: 20px 40px;
   display: flex;
 }
@@ -146,8 +147,9 @@
   background-color: lightblue;
   color: white;
   padding: 12px;
-  width: 60px;
-  margin: 5px 10px;
+  width: 70px;
+  height: 50px;
+  margin: 3px 3px;
   text-align: center;
 }
 

--- a/app/assets/stylesheets/messages.css
+++ b/app/assets/stylesheets/messages.css
@@ -112,6 +112,10 @@
   margin-bottom: 40px;
 }
 
+.message-content h2 {
+  color: black
+}
+
 .form{
   background-color: #DDDDDD;
   height: 200px;
@@ -127,7 +131,7 @@
 
 .form-message {
   border: none;
-  height: 50px;
+  height: 160px;
   width: 100%;
   padding-left: 10px;
 }

--- a/app/assets/stylesheets/messages.css
+++ b/app/assets/stylesheets/messages.css
@@ -160,3 +160,8 @@
 .hidden {
   display: none;
 }
+
+.code {
+  background-color: #d5cccc;
+  padding: 10px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
-  #before_action :basic_auth
+  before_action :basic_auth if Rails.env.production?
   private
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,8 @@ module ApplicationHelper
       link_attributes: true,     # リンクに追加する追加属性のハッシュ。
     }
 
-    renderer = Redcarpet::Render::HTML.new(options)
+    #renderer = Redcarpet::Render::HTML.new(options)
+    renderer = HTMLwithCoderay.new(options)
     markdown = Redcarpet::Markdown.new(renderer, extensions)
 
     markdown.render(text).html_safe
@@ -46,7 +47,7 @@ module ApplicationHelper
   # 言語での記述（シンタックスハイライト）の導入（coderay）
   class HTMLwithCoderay < Redcarpet::Render::HTML
     def block_code(code, language)
-      language = language.split(':')[0]
+      language = language.split(':')[0] if language.present?
       
       case language.to_s
       when 'rb'         # rb も rubyと認識させる。って意味。

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,69 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  # マークダウン形式の導入（redcarpet）
+  def markdown(text)
+    options = {
+      filter_html:     true,     # htmlを出力しない
+      hard_wrap:       true,     # マークダウン中の空行をhtmlに置き換え
+      space_after_headers: true, # # と文字の間にスペースを要求
+    }
+
+    extensions = {
+      autolink:           true,  # <>で囲まれてなくてもリンクを認識
+      no_intra_emphasis:  true,  # 単語中の強調を認識しない
+      fenced_code_blocks: true,  # フェンスのあるコードブロックを認識
+      strikethrough:      true,  # ~ 2つで取り消し線
+      superscript:        true,  # ^ の後ろが上付き文字
+      tables:             true,  # テーブルを認識
+      underline:          true,  # 斜線(* *)
+      highlight:          true,  # ハイライト(== ==)
+      quote:              true,  # 引用符(" ")
+      footnotes:          true,  # 脚注( ^[1] )
+
+      # 今回は不使用なので、間違ってるかも。こんなんもあるらしい程度。(詳細は、https://github.com/vmg/redcarpet)
+      xhtml: true,               # xhtml タグ出力(Render::XHTMLでは常に有効)
+      lax_html_blocks: true,     # HTMLブロックの上下の空行を不要にする
+      lax_spacing: true,         # HTMLブロックの空行を不要にする
+      no_images: true,           # img 要素を無効化
+      no_links: true,            # a 要素を無効化
+      no_styles: true,           # style 要素を無効化
+      safe_links_only: true,     # 安全なリンクだけ出力
+      disable_indented_code_blocks: true, # 通常のマークダウンを認識しない。(行の先頭にある4つのスペースを持つテキストのコードブロックへの変換を無効化（ fencedcode_blocks: true と一緒の使用推奨))
+      escape_html: true,         # HTMLタグをエスケープ。最優先され、:no_styles、:no_links、:no_images、:filter_html などは、削除ではなく、エスケープされる。
+      with_toc_data: true,       # リンクの許可のため、出力HTMLのヘッダーにHTMLアンカー追加する
+      prettify: true,            # prettyprintクラスを<code>google-code-prettifyタグに追加。
+      link_attributes: true,     # リンクに追加する追加属性のハッシュ。
+    }
+
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+
+    markdown.render(text).html_safe
+  end
+#------------------------------------------------------------------
+  # 言語での記述（シンタックスハイライト）の導入（coderay）
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(':')[0]
+      
+      case language.to_s
+      when 'rb'         # rb も rubyと認識させる。って意味。
+          lang = 'ruby'
+      when 'yml'
+          lang = 'yaml'
+      when 'css'
+          lang = 'css'
+      when 'html'
+          lang = 'html'
+      when ''
+          lang = 'md'  # 空欄だとエラー?（Invalid id given:）
+      else
+          lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
 end

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -1,7 +1,7 @@
 <div class = "chat-header">
   <div class = "left-header">
     <div class = "header-title">
-      <%= @room.name %>
+      <%= "Beginner #{@room.name}" %>
     </div>
   </div>
 

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -18,7 +18,7 @@
 
 <%= form_with model: [@room, @message], class: 'form', local: true do |f| %>
   <div class = "form-input">
-    <%= f.text_field :content, class: 'form-message', placeholder: 'type a message' %>
+    <%= f.text_area :content, class: 'form-message', placeholder: 'type a message' %>
     <label class = "form-image">
       <span class = "image-file">画像</span>
       <%= f.file_field :image, class: 'hidden' %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -12,8 +12,9 @@
   <div class="lower-message">
     <div class="message-content">
       <!-- 投稿したメッセージ内容を記述する -->
-      <%= message.content %>
+      <%= markdown(message.content) %>
+
     </div>
-    <%= image_tag message.image.variant(resize: '400x400'), class: 'message-image' if message.image.attached? %>
+    <%= image_tag message.image.variant(resize: '350x350'), class: 'message-image' if message.image.attached? %>
   </div>
 </div>

--- a/spec/system/rooms_spec.rb
+++ b/spec/system/rooms_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'チャットルームの削除機能', type: :system do
     FactoryBot.create_list(:message, 5, room_id: @room_user.room.id, user_id: @room_user.user.id)
     # 「チャットを終了する」ボタンをクリックすることで、作成した5つのメッセージが削除されていることを確認する
     expect {
-      find_link('チャットを終了する', href: room_path(@room_user.room)).click
+      find_link('チャット終了', href: room_path(@room_user.room)).click
     }.to change { @room_user.room.messages.count }.by(-5)
     # トップページに遷移していることを確認する
     expect(current_path).to eq(root_path)


### PR DESCRIPTION
# What
マークダウン記法とCSSの修正

# Why
チャット部分のメッセージにテキストと画像入力の他にとマークダウン記法にシンタックハイライトの適用の為。